### PR TITLE
Pushes to trie_builder now over-write previous values

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kv-trie-rs"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Sudarsan Reddy <sudar.theone@gmail.com>"]
 description = "KV capable prefix trie library based on LOUDS."
 readme = "README.md"
@@ -15,7 +15,7 @@ edition = "2021"
 louds-rs = "0.4"
 
 [dev-dependencies]
-criterion = "0.2"
+criterion = "0.4.0"
 rand = "0.6"
 lazy_static = "1.3"
 

--- a/src/internal_data_structure/naive_trie.rs
+++ b/src/internal_data_structure/naive_trie.rs
@@ -84,6 +84,6 @@ pub struct NaiveTrieIntermOrLeaf<K, V> {
     /// Sorted by Label's order.
     children: Vec<NaiveTrie<K, V>>,
     key: K,
-    value: V,
+    value: Option<V>,
     is_terminal: bool,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@
 //! ## Usage Overview
 //! ```rust
 //! use std::str;
-//! use trie_rs::TrieBuilder;
+//! use kv_trie_rs::TrieBuilder;
 //!
 //! let mut builder = TrieBuilder::new();  // Inferred `TrieBuilder<u8>` automatically
 //! builder.push("すし", 1);
@@ -23,7 +23,7 @@
 //! builder.push("すしづめ", 4);
 //! builder.push("すしめし", 5);
 //! builder.push("すしをにぎる", 6);
-//! builder.push("すし", 7);  // Word `push`ed twice is just ignored.
+//! builder.push("すし", 7);  // Word `push`ed twice is over-written.
 //! builder.push("🍣", 8);
 //!
 //! let mut trie = builder.build();
@@ -75,13 +75,13 @@
 //!    assert_eq!(
 //!    results_in_str,
 //!    vec![
-//!    ("すし", 1),
+//!    ("すし", 7),
 //!    ("すしや", 2),
 //!    ]  // Sorted by `Vec<u8>`'s order
 //!    );
 //!
 //! // get_value(): Get value of a word.
-//! assert_eq!(trie.get("すし"), Some(&1));
+//! assert_eq!(trie.get("すし"), Some(&7));
 //!
 //! // set value in a built trie.
 //! trie.set("すし", 9);
@@ -108,7 +108,7 @@
 //! Say `Label` is English words and `Arr` is English phrases.
 //!
 //! ```rust
-//! use trie_rs::TrieBuilder;
+//! use kv_trie_rs::TrieBuilder;
 //!
 //! let mut builder = TrieBuilder::new();
 //! builder.push(vec!["a", "woman"], 0 );
@@ -138,7 +138,7 @@
 //! Say `Label` is a digit in Pi (= 3.14...) and Arr is a window to separate pi's digit by 10.
 //!
 //! ```rust
-//! use trie_rs::TrieBuilder;
+//! use kv_trie_rs::TrieBuilder;
 //!
 //! let mut builder = TrieBuilder::<u8, u8>::new(); // Pi = 3.14...
 //!

--- a/src/trie.rs
+++ b/src/trie.rs
@@ -18,6 +18,6 @@ pub struct TrieBuilder<K, V> {
 
 struct TrieLabel<K, V> {
     key: K,
-    value: V,
+    value: Option<V>,
     is_terminal: bool,
 }


### PR DESCRIPTION
This does not affect any of the existing functionality. The only change here is that when a value is saved against a key, a push to the builder for the same key allows the existing value to be mutated/over-written.